### PR TITLE
use-nuxt-auth-module - Make auth package configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nuxt Auth Controller 
+# Nuxt Auth Controller
 [![NPM version][npm-image]][npm-url]
 
 > An easier approach to set up Auth within your Nuxt and Adonis project
@@ -8,6 +8,11 @@
 Install via the adonis cli
 ```sh
 $ npx @adonisjs/cli install @netsells/nuxt-auth-controller --yarn
+```
+
+Also install the auth package you wish to use:
+```sh
+yarn add -D @netsells/nuxt-auth
 ```
 
 ## Usage

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 import merge from 'lodash/merge';
 
-export default function AuthModule(moduleOptions = {}) {
+export default function AuthModule({
+    nuxtAuthModule = '@netsells/nuxt-auth',
+} = {}) {
     this.options.auth = merge({
         password_reset_url: '/password-reset?token=%TOKEN%',
 
@@ -22,7 +24,7 @@ export default function AuthModule(moduleOptions = {}) {
         redirect: false,
     }, this.options.auth || {});
 
-    this.requireModule('@nuxtjs/auth');
+    this.requireModule(nuxtAuthModule);
 
     /**
     * Handle the request intercept, and redirect the url to the API domain.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@netsells/nuxt-auth-controller",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "",
   "homepage": "",
   "author": {


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging

### Problem statement
Need to be able to use the netsells auth package

### Solution
Make it configurable using moduleOptions. Bumped version as this is a breaking change
